### PR TITLE
Use Geoapify API to autocomplete a city given some string input

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+
+.env

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Currently, we are using the `city` field from an influencer's `delivery_address`
 
 ### Problem 1: Influencers who live outside of the city they claim to operate in
 
-Imagine someone who spends most of my time in London, initially stating their local city is London. When this person later wants to enter their delivery address which resides in Dagenham (london not appearing in the address besides Greater London county), we would then be updating their City/Town as `Dagenham` despite it previously being given as London.
+Imagine someone who spends most of their time in London, initially stating their local city is London. When this person later wants to enter their delivery address which resides in Dagenham (london not appearing in the address besides Greater London county), we would then be updating their City/Town as `Dagenham` despite it previously being given as London.
 
 If we were to use the delivery address as the source of the `city` data, we would need to inform the Influencer what affect this has on their bids.
 
@@ -27,8 +27,84 @@ One could argue, that we could use the already provided `city` as a prefilled fi
 
 We could simply take the user's delivery address information as gospel here and override the pre-filled `city`. This then presents us again with `problem 1`.
 
-Another approach would be to not make the `city` field easily editable in the `deliver_address` form. We could intervene, showing the user a notice that changing their city would update their profile's `city` information. This isn't necessarily an issue for them placing the bid, however, if they were using a temporary address outside of the campaign's desired city, this might affect their bid's chances of being accepted.
+Another approach would be to not make the `city` field easily editable in the `delivery_address` form. We could intervene, showing the user a notice that changing their city would update their profile's `city` information. This isn't necessarily an issue for them placing the bid, however, if they were using a temporary address outside of the campaign's desired city, this might affect their bid's chances of being accepted.
 
 ### Problem 3: Multiple / Temporary Delivery Addresses
 
-It is not uncommon for eCommerce sites to offer the
+It is not uncommon for eCommerce sites to allow a user to choose one address from a list of previously provided ones. In this instance, how would we decide which address to use as the source of truth for the `city`?
+
+One solution would be to allow the influencer to mark an address as Primary. However, it seems that this would not solve `problem 1`. Rather, it might just minimise `problem 1`.
+
+
+## City Lookup / Autocomplete
+
+There are a number of 3rd party solutions to the problem we're trying to solve. Technically speaking, what we are looking for is the ability to [Forward Geocode](https://en.wikipedia.org/wiki/Address_geocoding) a given City name. Also, it's important that we can filter the search result items by a type parameter (i.e. return only cities).
+
+As part of this spike 3 third party solutions were considered, ArcGIS (ESRI), Geoapify and LocationIQ. Out of the many Geocoding APIs out there these three provided a good balance of cost, documentation, country & language support and usability. Other integrations that were considered include:
+
+- Google Places / Maps API: this was not chosen due to the high usage cost (per search), despite having arguably the best support worldwide.
+
+- Amazon Location Service: high usage cost, developer documentation looks quite lightweight since it's a fairly new amazon product.
+
+- Mapbox: insuffient support outside of the US & Canada
+
+The following third parties have been spiked in a Rails API application exposing a `/cities` endpoint. All 3 provide the Country coverage and language support that will enable us to epand into new territories.
+
+### ESRI (ArcGIS)
+
+#### Costs
+
+- 20,000 free searches per month
+- $0.50 / 1,000 searches after that
+
+#### Spike outcome
+
+See `esri.md` for details of the API response for 3 search terms.
+
+#### Impressions
+
+The quality of the data returned seems very accurate, although the data that's returned is just a long string containing the address information (e.g. "Manchester, Greater Manchester, England, GBR"). This might not be an issue, since technically it is a precise description of the city. We could use some frontend logic to truncate the string.
+
+### Geoapify
+
+#### Costs
+
+- 3,000 free searches per day (limited commercial use)
+- $49 / month would give 10,000 searches per day
+
+#### Spiked Solution
+
+See `geoapify.md` for details of the API response for 3 search terms.
+
+#### Impressions
+
+The data is returned in a richer structure than ESRI, breaking down each suggestion into its components like `city`, `state`, `country`, etc.
+
+One difficulty that I noticed was that in some responses the suggestion did not contain all of the given fields. In the `New Yo` search result list, some results return the `name` without the `city` attribute, whilst others return the converse. This might lead us to make assumptions about the domain logic used here which could lead to bugs for users in certain locations.
+
+### LocationIQ
+
+#### Costs
+
+- 5,000 free searches per day (limited commercial use) @ rate limit of 60/min
+- $49 / month would give 10,000 searches per day with no rate limit
+
+#### Spiked Solution
+
+See `location_iq.md` for details of the API response for 3 search terms.
+
+#### Impressions
+
+The data is returned in a richer structure than ESRI, but not as rich as Geoapify. However, the `display_name`, `display_place` pairing feels very useful. It would mean that we could save the pair in our database for displaying a more detailed view in certain UIs. For example, when a user types "New Yo", we could display a list of the `display_names` to them, allowing them to be sure they have selected the correct one. Once they make their selection, we could then populate the field with `display_place` for a more concise view.
+
+## Suggestions
+
+From spiking a basic implementation of City search, my recommendation is to use LocationIQ for the city lookup. The structure of data returned from the search is helpful, containing both detailed text to display to the user (e.g. Manchester, Greater Manchester, England, UK) and "place text" that can be used to refer to the city in the form (e.g. Manchester).
+
+Additionally, it looks like LocationIQ would be the best fit for us when looking at a delivery address lookup tool too.
+
+The main challenge with LocationIQ is that the "limited commercial use" flag on the free plan, tells us that we must display a prominent reference to LocationIQ:
+
+> You can use our free plan in commercial projects if you spread the love by adding a prominent link back to us on your website or app in this format: <a>Search by LocationIQ</a>.
+
+If this were to be too much of a hinderance to the UX, then I would recommend using ESRI due to its competitive pricing.

--- a/README.md
+++ b/README.md
@@ -1,24 +1,34 @@
-# README
+# SPK 43: Delivery Address and City Lookup / Autocompletion
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
+## Context
 
-Things you may want to cover:
+When influencers apply to the platform, it would benefit the CS team greatly if we could capture the influencer's City information. This would allow them to prioritise accepting influencers that live near Cities with upcoming campaigns running.
 
-* Ruby version
+This information would also be useful to store alongside approved influencers when on the platform, for the same purpose (but at the Bid Review stage).
 
-* System dependencies
+In November 2022, for example, the managed brand Billion Dollar Boy were running a Campaign for the Candy Crush Saga's 10th anniversary. They were looking for influencers to attend the in-person event in New York. The challenge was that the list of influencers we had did not include their locality information, so we had to wait for influencers to be accepted and their delivery details uploaded before knowing if they lived in New York city.
 
-* Configuration
 
-* Database creation
+## Delivery Address vs. City Lookup
 
-* Database initialization
+Currently, we are using the `city` field from an influencer's `delivery_address` as the source of data for the bid review and influencer application review screens. This does intuitively make sense, since Brands expect the city in the delivery address to align with the influencer's stated city. In practice though, this creates two problems.
 
-* How to run the test suite
+### Problem 1: Influencers who live outside of the city they claim to operate in
 
-* Services (job queues, cache servers, search engines, etc.)
+Imagine someone who spends most of my time in London, initially stating their local city is London. When this person later wants to enter their delivery address which resides in Dagenham (london not appearing in the address besides Greater London county), we would then be updating their City/Town as `Dagenham` despite it previously being given as London.
 
-* Deployment instructions
+If we were to use the delivery address as the source of the `city` data, we would need to inform the Influencer what affect this has on their bids.
 
-* ...
+A counterpoint to this is that an influencer could live far away from their stated city, and hence be misrepresenting themselves. To me, this feels like a different issue to what we're trying to solve here. Also, there are tools that we can use to help the CS team in addressing these misrepresentations. One suggestion would be to calculate the distance between the stated `city` and the new `delivery_address` and inform the influencer / CS team member of the discrepancy.
+
+### Problem 2: Lookup/Autocompletion of Address given a previously provided City
+
+One could argue, that we could use the already provided `city` as a prefilled field in the `delivery_address` form. This could provide a better user experience initially in the usual case (where `city == delivery_address.city`). In the case where these two don't align though, it's unclear what we should do here.
+
+We could simply take the user's delivery address information as gospel here and override the pre-filled `city`. This then presents us again with `problem 1`.
+
+Another approach would be to not make the `city` field easily editable in the `deliver_address` form. We could intervene, showing the user a notice that changing their city would update their profile's `city` information. This isn't necessarily an issue for them placing the bid, however, if they were using a temporary address outside of the campaign's desired city, this might affect their bid's chances of being accepted.
+
+### Problem 3: Multiple / Temporary Delivery Addresses
+
+It is not uncommon for eCommerce sites to offer the

--- a/app/controllers/cities_controller.rb
+++ b/app/controllers/cities_controller.rb
@@ -1,5 +1,7 @@
 class CitiesController < ApplicationController
   def index
-    render json: City.where(params[:q])
+    client = GeoapifyClient.new(type: "city")
+
+    render json: City.where(params[:q], client:)
   end
 end

--- a/app/controllers/cities_controller.rb
+++ b/app/controllers/cities_controller.rb
@@ -1,6 +1,6 @@
 class CitiesController < ApplicationController
   def index
-    client = ArcgisClient.new(type: "city")
+    client = LocationIQClient.new(type: "city")
 
     render json: City.where(params[:q], client:)
   end

--- a/app/controllers/cities_controller.rb
+++ b/app/controllers/cities_controller.rb
@@ -1,5 +1,5 @@
 class CitiesController < ApplicationController
   def index
-    render json: { hello: "world" }
+    render json: City.where(params[:q])
   end
 end

--- a/app/controllers/cities_controller.rb
+++ b/app/controllers/cities_controller.rb
@@ -1,7 +1,15 @@
 class CitiesController < ApplicationController
   def index
-    client = LocationIQClient.new(type: "city")
+    render json: City.where(params[:q], client: client_klass.new(type: "city"))
+  end
 
-    render json: City.where(params[:q], client:)
+  private
+
+  def client_klass
+    {
+      location_iq: LocationIQClient,
+      esri: ArcgisClient,
+      geoapify: GeoapifyClient,
+    }.fetch(params[:client].to_sym, LocationIQClient)
   end
 end

--- a/app/controllers/cities_controller.rb
+++ b/app/controllers/cities_controller.rb
@@ -1,6 +1,6 @@
 class CitiesController < ApplicationController
   def index
-    client = GeoapifyClient.new(type: "city")
+    client = ArcgisClient.new(type: "city")
 
     render json: City.where(params[:q], client:)
   end

--- a/app/models/city.rb
+++ b/app/models/city.rb
@@ -1,0 +1,27 @@
+class City
+  class << self
+    def where(search_string)
+      client.autocomplete(search_string).map do |result|
+        new(result)
+      end
+    end
+
+    private
+
+    def client
+      @client ||= GeoapifyClient.new(type: "city")
+    end
+  end
+
+  def initialize(city)
+    @city = city
+  end
+
+  def as_json(options = nil)
+    city.to_h
+  end
+
+  private
+
+  attr_reader :city
+end

--- a/app/models/city.rb
+++ b/app/models/city.rb
@@ -1,15 +1,9 @@
 class City
   class << self
-    def where(search_string)
+    def where(search_string, client: NullClient.new)
       client.autocomplete(search_string).map do |result|
         new(result)
       end
-    end
-
-    private
-
-    def client
-      @client ||= GeoapifyClient.new(type: "city")
     end
   end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -17,7 +17,7 @@ module Geoapify
     # in config/environments, which are processed later.
     #
     # config.time_zone = "Central Time (US & Canada)"
-    # config.eager_load_paths << Rails.root.join("extras")
+    config.eager_load_paths << Rails.root.join("lib")
 
     # Only loads a smaller set of middleware suitable for API only apps.
     # Middleware like session, flash, cookies can be added back manually.

--- a/esri.md
+++ b/esri.md
@@ -1,0 +1,96 @@
+```sh
+$ curl "http://localhost:3000/cities?q=Manch&client=esri"
+```
+```json
+[
+  {
+    "text": "Manchester, Greater Manchester, England, GBR",
+    "magicKey": "dHA9MCNsb2M9MTg4ODU0OTMjbG5nPTU0I3BsPTExNzYxNTcyI2xicz0xNDoyOTIyOTIwMw==",
+    "isCollection": false
+  },
+  {
+    "text": "Manchester, NH, USA (Hillsborough County)",
+    "magicKey": "dHA9MCNsb2M9NzUwODE0OCNsbmc9NTQjcGw9MTM0MTA2OCNsYnM9MTQ6MjkyMjkyMDM=",
+    "isCollection": false
+  },
+  {
+    "text": "Manchester Handia, England, GBR",
+    "magicKey": "dHA9MCNsb2M9MTg5MTE5NzkjbG5nPTIwI3BsPTExODkyNTI0I2xicz0xNDoyOTIyOTY2Ng==",
+    "isCollection": false
+  },
+  {
+    "text": "Manchester Twp, NJ, USA",
+    "magicKey": "dHA9MCNsb2M9ODIzMDE0MSNsbmc9NTQjcGw9MTQ3MTE0MCNsYnM9MTQ6MjkyMzAxNTg=",
+    "isCollection": false
+  },
+  {
+    "text": "Manchester, CT, USA (Hartford County)",
+    "magicKey": "dHA9MCNsb2M9ODYzNTgxNCNsbmc9NTQjcGw9MTYwNDkxOCNsYnM9MTQ6MjkyMjkyMDM=",
+    "isCollection": false
+  }
+]
+```
+```sh
+$ curl "http://localhost:3000/cities?q=New%20Yo&client=esri"
+```
+```json
+[
+  {
+    "text": "New York, NY, USA (New York County)",
+    "magicKey": "dHA9MCNsb2M9ODYxMjYxMSNsbmc9NTQjcGw9MTU4NDYxNCNsYnM9MTQ6MzI3ODM0ODE=",
+    "isCollection": false
+  },
+  {
+    "text": "New York, NY, USA",
+    "magicKey": "dHA9MCNsb2M9MTY0MTgzMjUjbG5nPTU0I3BsPTg1MjU4NTkjbGJzPTE0OjMyNzgzNDgx",
+    "isCollection": false
+  },
+  {
+    "text": "New York Mills, NY, USA (Oneida County)",
+    "magicKey": "dHA9MCNsb2M9ODM2NTcyNyNsbmc9NTQjcGw9MTUxMjg4MiNsYnM9MTQ6MzI3ODU1NDU=",
+    "isCollection": false
+  },
+  {
+    "text": "New York Mills, MN, USA (Otter Tail County)",
+    "magicKey": "dHA9MCNsb2M9NDQwMDM1MyNsbmc9NTQjcGw9ODIyODc0I2xicz0xNDozMjc4NTU0NQ==",
+    "isCollection": false
+  },
+  {
+    "text": "New York, East Lindsey, Lincolnshire, England, GBR",
+    "magicKey": "dHA9MCNsb2M9MTg4OTcwMDcjbG5nPTU0I3BsPTExODI2NDU0I2xicz0xNDozMjc4MzQ4MQ==",
+    "isCollection": false
+  }
+]
+```
+```sh
+$ curl "http://localhost:3000/cities?q=South&client=esri"
+```
+```json
+[
+  {
+    "text": "South Boston, MA, USA",
+    "magicKey": "dHA9MCNsb2M9Nzc4NDU1NiNsbmc9NTQjcGw9MTQwMjgzMiNsYnM9MTQ6NDM2MjU4NTk=",
+    "isCollection": false
+  },
+  {
+    "text": "Southampton, Hampshire, England, GBR",
+    "magicKey": "dHA9MCNsb2M9MTg4OTYyNzYjbG5nPTU0I3BsPTExODIyMDExI2xicz0xNDo0MzY1NjM2OA==",
+    "isCollection": false
+  },
+  {
+    "text": "South Bend, IN, USA",
+    "magicKey": "dHA9MCNsb2M9MTYwNzc2MiNsbmc9NTQjcGw9MzUyMjE3I2xicz0xNDo0MzYyNTMwMw==",
+    "isCollection": false
+  },
+  {
+    "text": "South Atlantic states, USA",
+    "magicKey": "dHA9MCNsb2M9MiNsbmc9NTQjcGw9OTIyMiNsYnM9MTQ6NDM2MjM3ODU=",
+    "isCollection": false
+  },
+  {
+    "text": "South East, England, GBR",
+    "magicKey": "dHA9MCNsb2M9MTg5MTE5NzkjbG5nPTU0I3BsPTExODkyNTIxI2xicz0xNDo0MzYzMjQxNQ==",
+    "isCollection": false
+  }
+]
+```

--- a/geoapify.md
+++ b/geoapify.md
@@ -1,0 +1,80 @@
+```sh
+$ curl "http://localhost:3000/cities?q=Manch&client=geoapify"
+```
+```json
+[
+  {
+    "country_code": "gb",
+    "city": "Manchester",
+    "state": "England"
+  },
+  {
+    "country_code": "us",
+    "city": "Manchester",
+    "state": "New Hampshire"
+  },
+  {
+    "country_code": "us",
+    "city": "Manchester",
+    "state": "Connecticut"
+  },
+  {
+    "country_code": "us",
+    "city": "West Manchester Township",
+    "state": "Pennsylvania"
+  },
+  {
+    "name": "Manchester Lakes",
+    "country_code": "us",
+    "city": "Hampshire",
+    "state": "Illinois"
+  }
+]
+```
+```sh
+$ curl "http://localhost:3000/cities?q=New%20Yo&client=geoapify"
+```
+```json
+[
+  {
+    "country_code": "us",
+    "city": "New York",
+    "state": "New York"
+  },
+  {
+    "name": "East New York",
+    "country_code": "us",
+    "city": "New York",
+    "state": "New York"
+  },
+  {
+    "country_code": "us",
+    "city": "West New York",
+    "state": "New Jersey"
+  },
+  {
+    "name": "Little New York",
+    "country_code": "us",
+    "state": "Alabama"
+  }
+]
+```
+```sh
+$ curl "http://localhost:3000/cities?q=South&client=geoapify"
+```
+```json
+[
+  {
+    "name": "South",
+    "country_code": "us",
+    "city": "South",
+    "state": "Kentucky"
+  },
+  {
+    "name": "Science Village",
+    "country_code": "us",
+    "city": "Science Village",
+    "state": "California"
+  }
+]
+```

--- a/lib/arcgis_client.rb
+++ b/lib/arcgis_client.rb
@@ -1,0 +1,38 @@
+class ArcgisClient
+  class Response
+    def initialize(data)
+      @data = data
+    end
+
+    def results
+      JSON.parse(@data.body)["suggestions"].map do |result|
+        OpenStruct.new(result["text"])
+      end
+    end
+  end
+
+  def initialize(type: :city)
+    @type = type
+    @api_key = ENV.fetch("ARCGIS_KEY")
+    @api_root = "https://geocode-api.arcgis.com/arcgis/rest/services/World/GeocodeServer"
+    @allowed_countries = [:us, :gb].join(",")
+  end
+
+  def autocomplete(search_string)
+    params = {
+      f: :json,
+      token: api_key,
+      category: type.to_s.upcase,
+      countryCode: allowed_countries.upcase,
+      text: search_string
+    }
+
+    Response.new(
+      Faraday.get("#{api_root}/suggest?#{params.to_query}")
+    ).results
+  end
+
+  private
+
+  attr_reader :type, :api_key, :api_root, :allowed_countries
+end

--- a/lib/arcgis_client.rb
+++ b/lib/arcgis_client.rb
@@ -6,7 +6,7 @@ class ArcgisClient
 
     def results
       JSON.parse(@data.body)["suggestions"].map do |result|
-        OpenStruct.new(result["text"])
+        OpenStruct.new(result)
       end
     end
   end

--- a/lib/geoapify_client.rb
+++ b/lib/geoapify_client.rb
@@ -1,0 +1,39 @@
+require "faraday"
+
+class GeoapifyClient
+  class Response
+    def initialize(data)
+      @data = data
+    end
+
+    def results
+      JSON.parse(@data.body)["features"].map do |result|
+        OpenStruct.new(result["properties"])
+      end
+    end
+  end
+
+  def initialize(type:)
+    @type = type
+    @api_root = "https://api.geoapify.com/v1/geocode"
+    @api_key = ENV.fetch("GEOAPIFY_KEY")
+    @allowed_countries = [:gb, :us].join(",")
+  end
+
+  def autocomplete(string)
+    params = {
+      text: string,
+      apiKey: api_key,
+      type: type,
+      filter: "countrycode:#{allowed_countries}"
+    }
+
+    Response.new(
+      Faraday.get("#{api_root}/autocomplete?#{params.to_query}")
+    ).results
+  end
+
+  private
+
+  attr_reader :api_root, :api_key, :type, :allowed_countries
+end

--- a/lib/geoapify_client.rb
+++ b/lib/geoapify_client.rb
@@ -8,7 +8,7 @@ class GeoapifyClient
 
     def results
       JSON.parse(@data.body)["features"].map do |result|
-        OpenStruct.new(result["properties"])
+        OpenStruct.new(result["properties"].slice("name", "country_code", "city", "state"))
       end
     end
   end

--- a/lib/location_i_q_client.rb
+++ b/lib/location_i_q_client.rb
@@ -1,0 +1,37 @@
+class LocationIQClient
+  class Response
+    def initialize(data)
+      @data = data
+    end
+
+    def results
+      JSON.parse(@data.body).map do |result|
+        OpenStruct.new(result.slice("display_name", "display_place"))
+      end
+    end
+  end
+
+  def initialize(type: :city)
+    @type = type
+    @api_key = ENV.fetch("LOCATION_IQ_KEY")
+    @api_host = "https://api.locationiq.com/v1"
+    @allowed_countries = [:us, :gb].join(",")
+  end
+
+  def autocomplete(search_string)
+    params = {
+      key: api_key,
+      q: search_string,
+      countrycodes: allowed_countries,
+      tag: "place:#{type}"
+    }
+
+    Response.new(
+      Faraday.get("#{api_host}/autocomplete?#{params.to_query}")
+    ).results
+  end
+
+  private
+
+  attr_reader :type, :api_key, :api_host, :allowed_countries
+end

--- a/lib/null_client.rb
+++ b/lib/null_client.rb
@@ -1,0 +1,5 @@
+class NullClient
+  def autocomplete(_)
+    []
+  end
+end

--- a/location_iq.md
+++ b/location_iq.md
@@ -1,0 +1,124 @@
+```sh
+$ curl "http://localhost:3000/cities?q=Manch&client=location_iq"
+```
+```json
+[
+  {
+    "display_name":"Manchester, Greater Manchester, England, M60 2UP, United Kingdom",
+    "display_place":"Manchester"
+  },
+  {
+    "display_name":"Manchester, Manchester, Hillsborough County, New Hampshire, 03104, USA",
+    "display_place":"Manchester"
+  },
+  {
+    "display_name":"Manchester, Manchester, Freeborn County, Minnesota, 56007, USA",
+    "display_place":"Manchester"
+  },
+  {
+    "display_name":"Manchester, Manchester, Dickinson County, Kansas, 67410, USA",
+    "display_place":"Manchester"
+  },
+  {
+    "display_name":"Manchester, Manchester, Saint Louis County, Missouri, 63021, USA",
+    "display_place":"Manchester"
+  },
+  {
+    "display_name":"Salford, Greater Manchester, England, M6 5RQ, United Kingdom",
+    "display_place":"Salford"
+  }
+]
+```
+```sh
+$ curl "http://localhost:3000/cities?q=New%20Yo&client=location_iq"
+```
+```json
+[
+  {
+    "display_name":"New York, New York, New York, 10007, USA",
+    "display_place":"New York"
+  },
+  {
+    "display_name":"New Rochelle, New Rochelle, Westchester County, New York, 10801, USA",
+    "display_place":"New Rochelle"
+  },
+  {
+    "display_name":"Kingston, Kingston, Ulster, New York, 12401, USA",
+    "display_place":"Kingston"
+  },
+  {
+    "display_name":"Buffalo, Buffalo, Erie County, New York, 14202, USA",
+    "display_place":"Buffalo"
+  },
+  {
+    "display_name":"Albany, Albany, Albany County, New York, 12207, USA",
+    "display_place":"Albany"
+  },
+  {
+    "display_name":"Rochester, Rochester, Monroe County, New York, 14614, USA",
+    "display_place":"Rochester"
+  },
+  {
+    "display_name":"Syracuse, Syracuse, Onondaga County, New York, 13202, USA",
+    "display_place":"Syracuse"
+  },
+  {
+    "display_name":"Middletown, Middletown, Orange County, New York, 10940, USA",
+    "display_place":"Middletown"
+  },
+  {
+    "display_name":"Watertown, Watertown, Jefferson County, New York, 13601, USA",
+    "display_place":"Watertown"
+  },
+  {
+  "display_name":"Peekskill, Peekskill, Westchester County, New York, 10566, USA",
+  "display_place":"Peekskill"
+  }
+```
+```sh
+$ curl "http://localhost:3000/cities?q=South&client=location_iq"
+```
+```json
+[
+  {
+    "display_name":"South Bend, South Bend, Saint Joseph County, Indiana, 46601, USA",
+    "display_place":"South Bend"
+  },
+  {
+    "display_name":"South Gate, South Gate, Los Angeles County, California, 90280, USA",
+    "display_place":"South Gate"
+  },
+  {
+    "display_name":"South Portland, South Portland, Cumberland County, Maine, 04106, USA",
+    "display_place":"South Portland"
+  },
+  {
+    "display_name":"South Haven, South Haven, Wright County, Minnesota, 55382, USA",
+    "display_place":"South Haven"
+  },
+  {
+    "display_name":"South St. Paul, South St. Paul, Minnesota, 55075, USA",
+    "display_place":"South St. Paul"
+  },
+  {
+    "display_name":"South Tucson, South Tucson, Pima County, Arizona, 85713, USA",
+    "display_place":"South Tucson"
+  },
+  {
+    "display_name":"South San Francisco, South San Francisco, San Mateo County, California, 94080, USA",
+    "display_place":"South San Francisco"
+  },
+  {
+    "display_name":"South Houston, South Houston, Harris County, Texas, 77587, USA",
+    "display_place":"South Houston"
+  },
+  {
+    "display_name":"South Park View, Minor Lane Heights, South Park View, Jefferson County, Kentucky, 40219, USA",
+    "display_place":"South Park View"
+  },
+  {
+    "display_name":"South English, South English, Keokuk County, Iowa, 52335, USA",
+    "display_place":"South English"
+  }
+]
+```


### PR DESCRIPTION
This technique allows us to filter the result set by Country as well as returning only City results.

For example, if the search string is "Lo" we could receive "london" or "loughborough" but not "tower of london", since "london" and "lougborough" are cities, but "tower of london" is not.